### PR TITLE
Update faircookbook_rdmkit_mapping.yml

### DIFF
--- a/faircookbook_rdmkit_mapping.yml
+++ b/faircookbook_rdmkit_mapping.yml
@@ -77,6 +77,10 @@
     fcb_id: FCB026
   - fcb_title: Interlinking data from different sources
     fcb_id: FCB016
+ - fcb_title: Introducing the DATS model
+    fcb_id:  FCB082
+ - fcb_title: Creating knowledge graphs from unstructured text
+    fcb_id:  FCB081
 
 - rdmkit_title: Documentation and metadata
   rdmkit_filename: metadata_management


### PR DESCRIPTION
linking FCB081 and FCB082 to RDMkit machine actionability page, as decided during today's joint meeting