### PR TITLE
Link in automatic issue + tagging corresponding team

### DIFF
--- a/.github/workflows/new_content_detection.yaml
+++ b/.github/workflows/new_content_detection.yaml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8]
+        python-version: [3.9]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/var/issue_creator.py
+++ b/var/issue_creator.py
@@ -106,7 +106,7 @@ repo = g.get_repo("elixir-europe/faircookbook-rdmkit")
 # FAIRCookbook
 for fcb_new_content_id, fcb_new_content_title in fcb_new_content.items():
     if fcb_new_content_id not in fcb_cached_content:
-        repo.create_issue(title=f"A new recipe was added to FCB: {fcb_new_content_id}", body=f"The recipe [{fcb_new_content_title}](/https://w3id.org/faircookbook/{fcb_new_content_id.removeprefix('#')}) was created. @elixir-europe/rdmkit-editors please check for possible connections with RDMkit pages.", labels=["new content","bot"])
+        repo.create_issue(title=f"A new recipe was added to FCB: {fcb_new_content_id}", body=f"The recipe [{fcb_new_content_title}](https://w3id.org/faircookbook/{fcb_new_content_id.removeprefix('#')}) was created. @elixir-europe/rdmkit-editors please check for possible connections with RDMkit pages.", labels=["new content","bot"])
         print(f"A new recipe was added to FCB: {fcb_new_content_id}")
 # RDMkit
 for rdmkit_new_content_id, rdmkit_new_content_title in rdmkit_new_content.items():

--- a/var/issue_creator.py
+++ b/var/issue_creator.py
@@ -106,12 +106,12 @@ repo = g.get_repo("elixir-europe/faircookbook-rdmkit")
 # FAIRCookbook
 for fcb_new_content_id, fcb_new_content_title in fcb_new_content.items():
     if fcb_new_content_id not in fcb_cached_content:
-        repo.create_issue(title=f"A new recipe was added to FCB: {fcb_new_content_id}", body=f"The recipe with FCB identifier {fcb_new_content_id} and title '{fcb_new_content_title}' was created.", labels=["new content","bot"])
+        repo.create_issue(title=f"A new recipe was added to FCB: {fcb_new_content_id}", body=f"The recipe [{fcb_new_content_title}](/https://w3id.org/faircookbook/{fcb_new_content_id.removeprefix('#')}) was created. @elixir-europe/rdmkit-editors please check for possible connections with RDMkit pages.", labels=["new content","bot"])
         print(f"A new recipe was added to FCB: {fcb_new_content_id}")
 # RDMkit
 for rdmkit_new_content_id, rdmkit_new_content_title in rdmkit_new_content.items():
     if rdmkit_new_content_id not in rdmkit_cached_content:
-        repo.create_issue(title=f"A new page was added to RDMkit: {rdmkit_new_content_id}", body=f"The page with RDMkit path {rdmkit_new_content_id} and title '{rdmkit_new_content_title}' was created.", labels=["new content","bot"])
+        repo.create_issue(title=f"A new page was added to RDMkit: {rdmkit_new_content_id}", body=f"The page [{rdmkit_new_content_title}](https://rdmkit.elixir-europe.org/{rdmkit_new_content_id}) was created. @elixir-europe/fair-cookbook-editors please check for possible connections with FAIRCookbook recipes.", labels=["new content","bot"])
         print(f"A new page was added to RDMkit: {rdmkit_new_content_id}")
 
 # ---- Update cached content files ----


### PR DESCRIPTION
This will close #27 and #26 bye:

Adding a url to the added page and tagging the other team in the body of the issue.