### PR TITLE
Change plant pages to correct FCB ID

### DIFF
--- a/faircookbook_rdmkit_mapping.yml
+++ b/faircookbook_rdmkit_mapping.yml
@@ -127,7 +127,7 @@
       databases
     fcb_id: FCB061
   - fcb_title: Publishing plant phenotypic data
-    fcb_id: FCB083PRE
+    fcb_id: FCB083
 
 - rdmkit_title: Plant Genomics
   rdmkit_filename: plant_genomics_assembly
@@ -140,7 +140,7 @@
   rdmkit_filename: plant_phenomics_assembly
   links:
   - fcb_title: Publishing plant phenotypic data
-    fcb_id: FCB083PRE
+    fcb_id: FCB083
 
 - rdmkit_title: Bioimaging data
   rdmkit_filename: bioimaging_data


### PR DESCRIPTION
This will fix #58 and https://github.com/elixir-europe/rdmkit/pull/1396 .

Faircookbook should still change the ID in their `_toc.yml` file https://github.com/FAIRplus/the-fair-cookbook/blob/main/_toc.yml


FCB083 exists as url, FCB083PRE not